### PR TITLE
Update "wikiedit" ID

### DIFF
--- a/docs/topics/oauth2.rst
+++ b/docs/topics/oauth2.rst
@@ -35,5 +35,5 @@ Scopes
    "submit","","Submit Content","Submit links and comments from my account."
    "subscribe","","Edit My Subscriptions","Manage my subreddit subscriptions. Manage "friends" - users whose content I follow."
    "vote","","Vote","Submit and change my votes on comments and submissions."
-   "wikiedit","wiki","Wiki Editing","Edit wiki pages on my behalf"
+   "wikiedit","","Wiki Editing","Edit wiki pages on my behalf"
    "wikiread","","Read Wiki Pages","Read wiki pages through my account"


### PR DESCRIPTION
Hello! /u/ThreeSixty404 here, you helped me on redditdev with the /prefs/ API confusion I had
  
I cloned this repo, installed python and compiled it, it is simply amazing, thanks!
  
About this PR  
I'm implementing the PATCH request for `/api/v1/me/prefs` and I was always having an error saying that the scope was insufficient, well turns out I was missing some of them, they are not documented on the official page, so I added them (thanks again) and this time I was having an issue with the authorization page saying "invalid scope".  
I modified the "wikiedit" scope to "wiki" as mentioned in your documentation and turn out it is wrong, the correct ID is "wikiedit"